### PR TITLE
fix some warnings

### DIFF
--- a/crontab-mode.el
+++ b/crontab-mode.el
@@ -183,7 +183,7 @@ Sets up command `font-lock-mode'.
     (erase-buffer)
     (crontab-mode)
     (crontab-insert host)
-    (not-modified)
+    (set-buffer-modified-p nil)
     (setq crontab-host host)) )
 
 (defun crontab-insert (&optional host)
@@ -231,7 +231,7 @@ Sets up command `font-lock-mode'.
 (defun crontab-host ()
   "Return the hostname as a string, defaulting to the local host.
 The variable `crontab-host' could be a symbol or a string."
-  (format "%s" (or crontab-host system-name)) )
+  (format "%s" (or crontab-host (system-name))) )
 
 ;;
 (defun crontab-after-save ()


### PR DESCRIPTION
I have fixed some warnings:

In crontab-get:
crontab-mode.el:186:6: Warning: ‘not-modified’ is for interactive use only; use ‘set-buffer-modified-p’ instead.

In crontab-host:
crontab-mode.el:234:33: Warning: ‘system-name’ is an obsolete variable (as of 25.1); use (system-name) instead

Since https://github.com/vkazanov/crontab-mode is archived in, your fork contains the latest version.
